### PR TITLE
Update instruction macros to use .insn directive

### DIFF
--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -23,16 +23,95 @@
 #define CAT_(A, B) A ## B
 #define CAT(A, B) CAT_(A, B)
 
+/** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
+  * assembly language instructions that will return data in rd. These
+  * are to be used only in assembly language programs (not C/C++).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_0 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION_RAW_R_R_R(0, a0, a1, a2, 42)
+  *
+  * This will produce the following pseudo assembly language
+  * instruction:
+  *
+  *     .insn r CUSTOM_0, 7, 42, a0, a1, a2
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rd the destination register, e.g., a0 or x10
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return a raw .insn RoCC instruction
+  */
 #define ROCC_INSTRUCTION_RAW_R_R_R(x, rd, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 7, func7, rd, rs1, rs2
 
+/** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
+  * assembly language instructions that will *NOT* return data in rd.
+  * These are to be used only in assembly language programs (not
+  * C/C++).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_1 instruction
+  * with func7 "42" that is doing some operation of "op(a1, a2). *NO*
+  * data is returned:
+  *
+  *     ROCC_INSTRUCTION_RAW_R_R_R(1, a1, a2, 42)
+  *
+  * This will produce the following pseudo assembly language
+  * instruction:
+  *
+  *     .insn r CUSTOM_1, 3, 42, x0, a1, a2
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return a raw .insn RoCC instruction
+  */
 #define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
 
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * This is equivalent to ROCC_INSTRUCTION_R_R_R. See it's
+  * documentation.
+  */
 #define ROCC_INSTRUCTION(x, rd, rs1, rs2, func7) \
   ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_2 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION(2, a0, a1, a2, 42)
+  *
+  * This will produce the following inline assembly:
+  *
+  *     asm volatile(
+  *         ".insn r CUSTOM_2, 0x7, 42, %0, %1, %2"
+  *         : "=r"(rd)
+  *         : "r"(rs1), "r"(rs2));
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rd the destination register, e.g., a0 or x10
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param func7 the value of the func7 field
+  * @return an inline assembly RoCC instruction
+  */
 #define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
   {                                                                     \
     asm volatile(                                                       \
@@ -41,6 +120,29 @@
         : "r"(rs1), "r"(rs2));                                          \
   }
 
+/** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
+  * (RoCC) instructions that return data in rd. These are to be used
+  * only in C/C++ programs (not bare assembly).
+  *
+  * Example:
+  *
+  * Consider the following macro consisting of a CUSTOM_3 instruction
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  *
+  *     ROCC_INSTRUCTION(3, a0, a1, a2, 42)
+  *
+  * This will produce the following inline assembly:
+  *
+  *     asm volatile(
+  *         ".insn r CUSTOM_3, 0x7, 42, %0, %1, %2"
+  *         :: "r"(rs1), "r"(rs2));
+  *
+  * @param x the custom instruction number: 0, 1, 2, or 3
+  * @param rs1 the first source register, e.g., a0 or x10
+  * @param rs2 the second source register, e.g., a0 or x10
+  * @param funct7 the value of the funct7 f
+  * @return an inline assembly RoCC instruction
+  */
 #define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
   {                                                                     \
     asm volatile(                                                       \

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -1,4 +1,4 @@
-// Copyright 2018 IBM
+// Copyright 2018--2020 IBM
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -20,7 +20,7 @@
 #define STR(x) STR1(x)
 #endif
 
-#define CAT_(A, B) A ## B
+#define CAT_(A, B) A##B
 #define CAT(A, B) CAT_(A, B)
 
 /** Assembly macro for creating "raw" Rocket Custom Coproessor (RoCC)
@@ -30,7 +30,7 @@
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_0 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)":
   *
   *     ROCC_INSTRUCTION_RAW_R_R_R(0, a0, a1, a2, 42)
   *
@@ -57,7 +57,7 @@
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_1 instruction
-  * with func7 "42" that is doing some operation of "op(a1, a2). *NO*
+  * with func7 "42" that is doing some operation of "op(a1, a2)". *NO*
   * data is returned:
   *
   *     ROCC_INSTRUCTION_RAW_R_R_R(1, a1, a2, 42)
@@ -76,7 +76,6 @@
 #define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
   .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
 
-
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
   * (RoCC) instructions that return data in rd. These are to be used
   * only in C/C++ programs (not bare assembly).
@@ -88,13 +87,14 @@
   ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
 
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
-  * (RoCC) instructions that return data in rd. These are to be used
-  * only in C/C++ programs (not bare assembly).
+  * (RoCC) instructions that return data in C variable rd. 
+  * These are to be used only in C/C++ programs (not bare assembly).
   *
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_2 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)"
+  * (where a0, a1, and a2 are variables defined in C):
   *
   *     ROCC_INSTRUCTION(2, a0, a1, a2, 42)
   *
@@ -106,28 +106,29 @@
   *         : "r"(rs1), "r"(rs2));
   *
   * @param x the custom instruction number: 0, 1, 2, or 3
-  * @param rd the destination register, e.g., a0 or x10
-  * @param rs1 the first source register, e.g., a0 or x10
-  * @param rs2 the second source register, e.g., a0 or x10
+  * @param rd the C variable to capture as destination operand
+  * @param rs1 the C variable to capture for first source register
+  * @param rs2 the C variable to capture for second source register
   * @param func7 the value of the func7 field
   * @return an inline assembly RoCC instruction
   */
-#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
-  {                                                                     \
-    asm volatile(                                                       \
+#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                               \
+  {                                                                                  \
+    asm volatile(                                                                    \
         ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x7) ", " STR(func7) ", %0, %1, %2" \
-        : "=r"(rd)                                                      \
-        : "r"(rs1), "r"(rs2));                                          \
+        : "=r"(rd)                                                                   \
+        : "r"(rs1), "r"(rs2));                                                       \
   }
 
 /** C/C++ inline assembly macro for creating Rocket Custom Coprocessor
-  * (RoCC) instructions that return data in rd. These are to be used
-  * only in C/C++ programs (not bare assembly).
+  * (RoCC) instructions that return data in C variable rd.
+  * These are to be used only in C/C++ programs (not bare assembly).
   *
   * Example:
   *
   * Consider the following macro consisting of a CUSTOM_3 instruction
-  * with func7 "42" that is doing some operation of "a0 = op(a1, a2):
+  * with func7 "42" that is doing some operation of "a0 = op(a1, a2)"
+  * (where a0, a1, and a2 are variables defined in C):
   *
   *     ROCC_INSTRUCTION(3, a0, a1, a2, 42)
   *
@@ -138,16 +139,17 @@
   *         :: "r"(rs1), "r"(rs2));
   *
   * @param x the custom instruction number: 0, 1, 2, or 3
-  * @param rs1 the first source register, e.g., a0 or x10
-  * @param rs2 the second source register, e.g., a0 or x10
+  * @param rs1 the C variable to capture for first source register
+  * @param rs2 the C variable to capture for second source register
   * @param funct7 the value of the funct7 f
   * @return an inline assembly RoCC instruction
   */
-#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
-  {                                                                     \
-    asm volatile(                                                       \
+#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                                   \
+  {                                                                                  \
+    asm volatile(                                                                    \
         ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x3) ", " STR(func7) ", x0, %0, %1" \
-        :: "r"(rs1), "r"(rs2));                                         \
+        :                                                                            \
+        : "r"(rs1), "r"(rs2));                                                       \
   }
 
 // [TODO] fix these to align with the above approach

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -19,62 +19,32 @@
 #ifndef STR
 #define STR(x) STR1(x)
 #endif
-#define EXTRACT(a, size, offset) (((~(~0 << size) << offset) & a) >> offset)
 
-// rd = rs2[offset + size - 1 : offset]
-// rs1 is clobbered
-// rs2 is left intact
-#define EXTRACT_RAW(rd, rs1, rs2, size, offset) \
-  not x ## rs1, x0;                             \
-  slli x ## rs1, x ## rs1, size;                \
-  not x ## rs1, x ## rs1;                       \
-  slli x ## rs1, x ## rs1, offset;              \
-  and x ## rd, x ## rs1, x ## rs2;              \
-  srai x ## rd, x ## rd, offset;
-
-#define XCUSTOM_OPCODE(x) XCUSTOM_OPCODE_ ## x
+#define XCUSTOM_OPCODE(x) XCUSTOM_OPCODE_##x
 #define XCUSTOM_OPCODE_0 0b0001011
 #define XCUSTOM_OPCODE_1 0b0101011
 #define XCUSTOM_OPCODE_2 0b1011011
 #define XCUSTOM_OPCODE_3 0b1111011
 
-#define XCUSTOM(x, rd, rs1, rs2, funct)         \
-  XCUSTOM_OPCODE(x)                   |         \
-  (rd                   << (7))       |         \
-  (0x3                  << (7+5))     |         \
-  ((rd != 0) & 1        << (7+5+2))   |         \
-  (rs1                  << (7+5+3))   |         \
-  (rs2                  << (7+5+3+5)) |         \
-  (EXTRACT(funct, 7, 0) << (7+5+3+5+5))
-
-#define ROCC_INSTRUCTION_RAW_R_R_R(x, rd, rs1, rs2, funct)      \
-  .word XCUSTOM(x, ## rd, ## rs1, ## rs2, funct)
-
 // Standard macro that passes rd, rs1, and rs2 via registers
-#define ROCC_INSTRUCTION(x, rd, rs1, rs2, funct)                \
-  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct, 10, 11, 12)
+#define ROCC_INSTRUCTION(x, rd, rs1, rs2, funct7) \
+  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)
 
 // rd, rs1, and rs2 are data
-// rd_n, rs1_n, and rs2_n are the register numbers to use
-#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct, rd_n, rs1_n, rs2_n) \
-  {                                                                     \
-    register uint64_t rd_  asm ("x" # rd_n);                            \
-    register uint64_t rs1_ asm ("x" # rs1_n) = (uint64_t) rs1;          \
-    register uint64_t rs2_ asm ("x" # rs2_n) = (uint64_t) rs2;          \
-    asm volatile (                                                      \
-        ".word " STR(XCUSTOM(x, rd_n, rs1_n, rs2_n, funct)) "\n\t"      \
-        : "=r" (rd_)                                                    \
-        : [_rs1] "r" (rs1_), [_rs2] "r" (rs2_));                        \
-    rd = rd_;                                                           \
+#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)                                 \
+  {                                                                                     \
+    asm volatile(                                                                       \
+        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", %0, %1, %2" \
+        : "=r"(rd)                                                                      \
+        : "r"(rs1), "r"(rs2));                                                          \
   }
 
-#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct, rs1_n, rs2_n)  \
-  {                                                               \
-    register uint64_t rs1_ asm ("x" # rs1_n) = (uint64_t) rs1;    \
-    register uint64_t rs2_ asm ("x" # rs2_n) = (uint64_t) rs2;    \
-    asm volatile (                                                \
-        ".word " STR(XCUSTOM(x, 0, rs1_n, rs2_n, funct)) "\n\t"   \
-        :: [_rs1] "r" (rs1_), [_rs2] "r" (rs2_));                 \
+#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct7)                                     \
+  {                                                                                     \
+    asm volatile(                                                                       \
+        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", x0, %0, %1" \
+        :                                                                               \
+        : "r"(rs1), "r"(rs2));                                                          \
   }
 
 // [TODO] fix these to align with the above approach

--- a/src/xcustom.h
+++ b/src/xcustom.h
@@ -20,31 +20,32 @@
 #define STR(x) STR1(x)
 #endif
 
-#define XCUSTOM_OPCODE(x) XCUSTOM_OPCODE_##x
-#define XCUSTOM_OPCODE_0 0b0001011
-#define XCUSTOM_OPCODE_1 0b0101011
-#define XCUSTOM_OPCODE_2 0b1011011
-#define XCUSTOM_OPCODE_3 0b1111011
+#define CAT_(A, B) A ## B
+#define CAT(A, B) CAT_(A, B)
 
-// Standard macro that passes rd, rs1, and rs2 via registers
-#define ROCC_INSTRUCTION(x, rd, rs1, rs2, funct7) \
-  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)
+#define ROCC_INSTRUCTION_RAW_R_R_R(x, rd, rs1, rs2, func7) \
+  .insn r CAT(CUSTOM_, x), 7, func7, rd, rs1, rs2
 
-// rd, rs1, and rs2 are data
-#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, funct7)                                 \
-  {                                                                                     \
-    asm volatile(                                                                       \
-        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", %0, %1, %2" \
-        : "=r"(rd)                                                                      \
-        : "r"(rs1), "r"(rs2));                                                          \
+#define ROCC_INSTRUCTION_RAW_0_R_R(x, rs1, rs2, func7) \
+  .insn r CAT(CUSTOM_, x), 3, func7, x0, rs1, rs2
+
+
+#define ROCC_INSTRUCTION(x, rd, rs1, rs2, func7) \
+  ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)
+
+#define ROCC_INSTRUCTION_R_R_R(x, rd, rs1, rs2, func7)                 \
+  {                                                                     \
+    asm volatile(                                                       \
+        ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x7) ", " STR(func7) ", %0, %1, %2" \
+        : "=r"(rd)                                                      \
+        : "r"(rs1), "r"(rs2));                                          \
   }
 
-#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, funct7)                                     \
-  {                                                                                     \
-    asm volatile(                                                                       \
-        ".insn r " STR(XCUSTOM_OPCODE(x)) ", " STR(0x3) ", " STR(funct7) ", x0, %0, %1" \
-        :                                                                               \
-        : "r"(rs1), "r"(rs2));                                                          \
+#define ROCC_INSTRUCTION_0_R_R(x, rs1, rs2, func7)                     \
+  {                                                                     \
+    asm volatile(                                                       \
+        ".insn r " STR(CAT(CUSTOM_, x)) ", " STR(0x3) ", " STR(func7) ", x0, %0, %1" \
+        :: "r"(rs1), "r"(rs2));                                         \
   }
 
 // [TODO] fix these to align with the above approach


### PR DESCRIPTION
The prior solution relied on deprecated register storage class specifiers.
Note that .insn directives require a sufficiently recent version of binutils.

Addresses issue #3.

DCO 1.1 Signed-off-by: Pranav Prakash <pranav-prakash@users.noreply.github.com>